### PR TITLE
Ensure a project exists first in `gptel-prompts-project-conventions` to avoid nil errors

### DIFF
--- a/gptel-prompts.el
+++ b/gptel-prompts.el
@@ -340,7 +340,8 @@ the default directive, use:
 
   (setf (alist-get \\'default gptel-directives)
         #\\'gptel-project-conventions)"
-  (when-let ((root (project-root (project-current))))
+  (when-let* ((project (project-current))
+              (root (project-root project)))
     (with-memoization
         (alist-get root gptel-prompts--project-conventions-alist
                    nil nil #'equal)


### PR DESCRIPTION
Hi, thanks for the package.

This function is part of my `default` directive (I wrap it w/ another function that appends my custom, global conventions too) and realized it causes an error when I try to use it on projects that are not version controlled.

`project-current` would return `nil`, which would then fault `project-root`.

This change worked well for me.
