### PR TITLE
Add to instruction default list: AGENTS.md

### DIFF
--- a/gptel-prompts.el
+++ b/gptel-prompts.el
@@ -325,6 +325,7 @@ for typed files."
 (defcustom gptel-prompts-project-files
   '("CONVENTIONS.md"
     "CLAUDE.md"
+    "AGENTS.md"
     (".github" . "copilot-instructions\\.md")
     (".instructions.d" . "^.*\\.md$")
     ".instructions.md")


### PR DESCRIPTION
I recently discovered https://agent-rules.org/ and it seems to be an emerging tool agnostic standard.

This can already be easily customized with `gptel-prompts-project-conventions` thanks to the current design but may perhaps be useful as an included default. I have already customized this locally but wanted to open the suggestion in case you wanted to include.

No offense if you choose to ignore or take a different route and thanks for this package!